### PR TITLE
Refactor base classes and hotfix for few bugs

### DIFF
--- a/musicutil/MusicSource.py
+++ b/musicutil/MusicSource.py
@@ -243,7 +243,7 @@ class chiasenhac_vn(BaseSource):
             data = [line for line in get_inner_texts(a_download)]
 
             if len(data) == 1 and chiasenhac_vn._M4A_32_STR in data[0] : 
-                size = data[0][len(chiasenhac_vn._M4A_32_STR):].strip()
+                size = data[0].split(chiasenhac_vn._M4A_32_STR)[1].strip()
                 quality = chiasenhac_vn.Quality.m4a_32kbps
 
             elif len(data) == 3:

--- a/musicutil/MusicSource.py
+++ b/musicutil/MusicSource.py
@@ -44,7 +44,6 @@ class SourceException(Exception):
 
 
 class BaseSource(object):
-    """Base class for all music sources."""
 
     def __init__(self, prefix, header, name="", trace=False, trace_out=False, 
                 requests_session = None, proxies=None, requests_timeout=None):
@@ -69,6 +68,18 @@ class BaseSource(object):
             else:  # Use the Requests API module as a "session".
                 from requests import api
                 self._session = api
+
+    
+
+
+class BaseSourceScrapper(BaseSource):
+    """Base class for all music sources."""
+
+    def __init__(self, prefix, header, name="", trace=False, trace_out=False, 
+                requests_session = None, proxies=None, requests_timeout=None):
+        super().__init__(self._PREFIX, self._HEADERS, self._NAME, trace,
+                         trace_out, requests_session, proxies, requests_timeout)
+
 
 
     def _internal_call(self, method, url, return_json, payload, params):
@@ -148,7 +159,7 @@ class BaseSource(object):
 #Music Source Classes#
 #----------------------------------------------
 
-class chiasenhac_vn(BaseSource):
+class chiasenhac_vn(BaseSourceScrapper):
     
     _PREFIX = 'http://chiasenhac.vn/'
     _NAME = 'chiasenhac.vm'
@@ -474,15 +485,14 @@ class chiasenhac_vn(BaseSource):
 
 
 
-
 #Register music sources( class which inherit 'BaseSource')
 for name, class_type in inspect.getmembers(sys.modules[__name__], 
         lambda member: inspect.isclass(member) and member.__module__ == __name__):
-
-    source_class, *base_classes = inspect.getmro(class_type)
-    if BaseSource in base_classes:
-        #update the dict 
-        SOURCES.update({name:source_class})
+    if not name == "BaseSourceScrapper":                                                #TODO: Replace this Hardcoded hotfix with
+        source_class, *base_classes = inspect.getmro(class_type)                        #      permanent fix.
+        if BaseSource in base_classes:
+            #update the dict 
+            SOURCES.update({name:source_class})
 
 if not SOURCES:
     warnings.warn(_NO_SOURCE_WARNING)
@@ -502,5 +512,6 @@ def get_source(name=None):
         except KeyError:
             raise KeyError("No source named {} found.".format(name))
     
+
 
 


### PR DESCRIPTION
Refactor the `BaseSource` class into `BaseSource` and `BaseSourceScrapper` as it contains methods which were useless for music source which does not depends upon scrapping like Spotify. So new base classes inheriting `BaseSource` (new one)  named "BaseSourceScrapper" is created for srcapping sources